### PR TITLE
Add RBAC rules for services, pods and deployments

### DIFF
--- a/operator/PROJECT
+++ b/operator/PROJECT
@@ -2,6 +2,6 @@ domain: keda.sh
 repo: github.com/kedacore/http-add-on
 resources:
 - group: http
-  kind: HTTPHTTPScaledObject
+  kind: HTTPScaledObject
   version: v1alpha1
 version: "2"

--- a/operator/controllers/httpscaledobject_controller.go
+++ b/operator/controllers/httpscaledobject_controller.go
@@ -42,6 +42,8 @@ type HTTPScaledObjectReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=http.keda.sh,resources=scaledobjects,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods;services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=http.keda.sh,resources=scaledobjects/status,verbs=get;update;patch
 
 // Reconcile reconciles a newly created, deleted, or otherwise changed

--- a/operator/controllers/httpscaledobject_controller.go
+++ b/operator/controllers/httpscaledobject_controller.go
@@ -113,8 +113,8 @@ func (rec *HTTPScaledObjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 }
 
 // SetupWithManager starts up reconciliation with the given manager
-func (r *HTTPScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (rec *HTTPScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&httpv1alpha1.HTTPScaledObject{}).
-		Complete(r)
+		Complete(rec)
 }


### PR DESCRIPTION
Adds kubebuilder RBAC rules for pods, deployments and services.

> Note: it might be needed to re-run `make`

**Merge after #4**